### PR TITLE
Implement per-fan refresh button

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -621,3 +621,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-11: Added winston logging and feature toggles in cron jobs; documented production env.
 - 2025-07-12: Improved .env handling and environment checks before DB init.
 - 2025-07-13: initDb now creates .env if missing and exits with instructions.
+- 2025-07-16: Added single-fan refresh button in SyncDashboard.vue.

--- a/src/client/components/SyncDashboard.vue
+++ b/src/client/components/SyncDashboard.vue
@@ -1,3 +1,7 @@
+<!-- OnlyFans Automation Manager
+     File: SyncDashboard.vue
+     Purpose: manual and incremental data sync UI
+     Created: 2025-07-06 – v1.0 -->
 <template>
   <div>
     <h2 class="text-xl font-semibold mb-2">Data Sync</h2>
@@ -7,31 +11,45 @@
     <p v-if="status" class="mt-2">{{ status }}</p>
 
     <h3 class="text-lg font-semibold mt-6 mb-2">Fans (first 100)</h3>
-    <table class="w-full border bg-white">
-      <thead><tr class="bg-slate-100">
-        <th class="p-2 text-left">Name</th><th class="p-2">User</th>
-        <th class="p-2">Status</th><th class="p-2 text-right">Spend $</th>
-      </tr></thead>
-      <tbody>
-        <tr v-for="f in fans" :key="f.fan_id">
-          <td class="p-2">{{ f.display_name }}</td>
-          <td class="p-2">@{{ f.username }}</td>
-          <td class="p-2">{{ f.subscription_status }}</td>
-          <td class="p-2 text-right">{{ f.spend_total }}</td>
-        </tr>
-      </tbody>
-    </table>
+      <table class="w-full border bg-white">
+        <thead><tr class="bg-slate-100">
+          <th class="p-2 text-left">Name</th>
+          <th class="p-2">User</th>
+          <th class="p-2">Status</th>
+          <th class="p-2 text-right">Spend $</th>
+          <th class="p-2">Actions</th>
+        </tr></thead>
+        <tbody>
+          <tr v-for="f in fans" :key="f.fan_id">
+            <td class="p-2">{{ f.display_name }}</td>
+            <td class="p-2">@{{ f.username }}</td>
+            <td class="p-2">{{ f.subscription_status }}</td>
+            <td class="p-2 text-right">{{ f.spend_total }}</td>
+            <td class="p-2 text-center">
+              <button class="btn btn-sm" :disabled="refreshing===f.fan_id" @click="refreshFan(f.fan_id)">
+                {{ refreshing===f.fan_id ? '...' : '🔄' }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
-const busy=ref(false), status=ref(''), fans=ref([])
+const busy=ref(false), status=ref(''), fans=ref([]), refreshing=ref(null)
 
 async function syncAll(){
   busy.value=true; status.value='Running sync…'
   const r=await fetch('/api/sync',{method:'POST'})
   busy.value=false; status.value=r.ok?'✅ done':'❌ failed'
+  if(r.ok) loadFans()
+}
+async function refreshFan(id){
+  refreshing.value=id; status.value='Refreshing…'
+  const r=await fetch(`/api/fans/${id}/sync`,{method:'POST'})
+  refreshing.value=null; status.value=r.ok?'✅ refreshed':'❌ failed'
   if(r.ok) loadFans()
 }
 async function loadFans(){
@@ -41,4 +59,9 @@ async function loadFans(){
 onMounted(loadFans)
 </script>
 
-<style scoped>.btn{@apply bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700}</style>
+<style scoped>
+.btn{@apply bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700}
+.btn-sm{@apply px-2 py-1 text-sm}
+</style>
+
+<!-- End of File – Last modified 2025-07-16 -->


### PR DESCRIPTION
## Summary
- allow refreshing a single fan in **SyncDashboard**
- note change in the project plan revision log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878665b1fe48321b1149425355a022a