### PR TITLE
Add ActivityLog component

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -624,3 +624,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-16: Added single-fan refresh button in SyncDashboard.vue.
 - 2025-07-17: Added optional ?max=N sync limit and Sync 10 button for testing.
 - 2025-07-17: Added in-memory sync activity log and /api/log endpoint.
+- 2025-07-17: Added ActivityLog.vue component to display sync log in UI.

--- a/src/client/components/ActivityLog.vue
+++ b/src/client/components/ActivityLog.vue
@@ -1,0 +1,34 @@
+<!-- OnlyFans Automation Manager
+     File: ActivityLog.vue
+     Purpose: display real-time sync log
+     Created: 2025-07-17 – v1.0 -->
+<template>
+  <pre ref="logBox" class="bg-slate-100 text-sm font-mono p-2 h-72 overflow-y-auto whitespace-pre-wrap">{{ logText }}</pre>
+</template>
+
+<script setup>
+import { ref, onMounted, onUnmounted, nextTick } from 'vue'
+
+const logText = ref('')
+const logBox = ref(null)
+let timer
+
+async function fetchLog() {
+  const res = await fetch('/api/log')
+  if (res.ok) {
+    const data = await res.json()
+    logText.value = Array.isArray(data.log) ? data.log.join('\n') : (data.log || '')
+    await nextTick()
+    if (logBox.value) logBox.value.scrollTop = logBox.value.scrollHeight
+  }
+}
+
+onMounted(() => {
+  fetchLog()
+  timer = setInterval(fetchLog, 2000)
+})
+
+onUnmounted(() => { if (timer) clearInterval(timer) })
+</script>
+
+<!-- End of File – Last modified 2025-07-17 -->

--- a/src/client/components/SyncDashboard.vue
+++ b/src/client/components/SyncDashboard.vue
@@ -36,11 +36,15 @@
           </tr>
         </tbody>
       </table>
+
+    <h3 class="text-lg font-semibold mt-6 mb-2">Activity Log</h3>
+    <ActivityLog />
   </div>
 </template>
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import ActivityLog from './ActivityLog.vue'
 const busy=ref(false), status=ref(''), fans=ref([]), refreshing=ref(null)
 
 async function syncAll(max){


### PR DESCRIPTION
## Summary
- create `ActivityLog.vue` component polling `/api/log`
- integrate `ActivityLog` into `SyncDashboard`
- document new component in `PROJECT_PLAN`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878757f0e2c8321a967ccd79722fa4f