### PR TITLE
Add messaging components to dashboard

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -625,3 +625,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-17: Added optional ?max=N sync limit and Sync 10 button for testing.
 - 2025-07-17: Added in-memory sync activity log and /api/log endpoint.
 - 2025-07-17: Added ActivityLog.vue component to display sync log in UI.
+- 2025-07-17: Integrated DmComposer and MassBlast components into MessagingDashboard.

--- a/src/client/components/MessagingDashboard.vue
+++ b/src/client/components/MessagingDashboard.vue
@@ -3,18 +3,24 @@
      Purpose: shell for DMs inbox / composer
      Created: 2025-07-16 – v1.0 -->
 <template>
-  <div class="p-4">
+  <div class="p-4 space-y-6">
     <h2 class="text-xl font-semibold mb-4">Messages</h2>
 
-    <!-- stub content -->
-    <p class="text-slate-500">
-      Inbox coming soon …
-    </p>
+    <div>
+      <DmComposer />
+    </div>
+
+    <hr />
+
+    <div>
+      <MassBlast />
+    </div>
   </div>
 </template>
 
 <script setup>
-/* empty for now */
+import DmComposer from './DmComposer.vue'
+import MassBlast from './MassBlast.vue'
 </script>
 
-<!-- End of File – Last modified 2025-07-16 -->
+<!-- End of File – Last modified 2025-07-17 -->


### PR DESCRIPTION
## Summary
- integrate DmComposer and MassBlast inside `MessagingDashboard.vue`
- document the update in the project plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687877416c8c8321a068f3fe474f7393