### PR TITLE
Fix profile visitors analytics endpoint

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -627,3 +627,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-17: Added ActivityLog.vue component to display sync log in UI.
 - 2025-07-17: Integrated DmComposer and MassBlast components into MessagingDashboard.
 - 2025-07-17: Embedded PostManager and QueueView in ContentDashboard for content scheduling.
+- 2025-07-19: Fixed profile visitors analytics endpoint to return proper count.

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -103,13 +103,14 @@ app.get('/api/auth/:id', async (req, res) => {
     res.status(500).json({ error: 'auth poll failed' });
   }
 });
-app.get('/api/profile-visitors', async (req,res)=>{
-  try{
-    const acct=await getCurrentAccount()
-    const data=await safeGET(`/api/${acct.id}/statistics/reach/profile-visitors`)
-    res.json({count:data.data?.count||0})
-  }catch(e){res.status(500).json({error:'fail'})}
-})
+// Duplicate endpoint removed. Use the withAccount version below.
+// app.get('/api/profile-visitors', async (req,res)=>{
+//   try{
+//     const acct=await getCurrentAccount()
+//     const data=await safeGET(`/api/${acct.id}/statistics/reach/profile-visitors`)
+//     res.json({count:data.data?.count||0})
+//   }catch(e){res.status(500).json({error:'fail'})}
+// })
 app.post('/api/auth/:id/2fa', async (req, res) => {
   try {
     const { code } = req.body;
@@ -322,7 +323,7 @@ app.get('/api/experiments', async (_, res) => {
 
 app.get('/api/profile-visitors', withAccount(async (_, res, acct) => {
   const data = await safeGET(`/api/${acct}/statistics/reach/profile-visitors`);
-  res.json(data);
+  res.json({ count: data.data?.count || 0 });
 }));
 
 // GDPR export & delete
@@ -455,4 +456,4 @@ app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
 
-/*  End of File – Last modified 2025-07-17 */
+/*  End of File – Last modified 2025-07-19 */


### PR DESCRIPTION
## Summary
- remove duplicate `/api/profile-visitors` endpoint
- return only `{ count }` from remaining profile visitor API
- update revision log for this bugfix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68787b31884c8321bbf8da968d874fa2