### PR TITLE
Fix LTV endpoint response and integrate card

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -628,3 +628,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-17: Integrated DmComposer and MassBlast components into MessagingDashboard.
 - 2025-07-17: Embedded PostManager and QueueView in ContentDashboard for content scheduling.
 - 2025-07-19: Fixed profile visitors analytics endpoint to return proper count.
+- 2025-07-20: Updated LTV endpoint response and integrated LtvCard into analytics dashboard.

--- a/src/client/components/AnalyticsDashboard.vue
+++ b/src/client/components/AnalyticsDashboard.vue
@@ -5,12 +5,14 @@
 <template>
   <div class="grid gap-4 p-4 md:grid-cols-2 lg:grid-cols-3">
     <ProfileVisitors />
+    <LtvCard />
     <!-- more analytics widgets soon -->
   </div>
 </template>
 
 <script setup>
 import ProfileVisitors from './ProfileVisitors.vue'
+import LtvCard from './LtvCard.vue'
 </script>
 
-<!-- End of File – Last modified 2025-07-16 -->
+<!-- End of File – Last modified 2025-07-20 -->

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -253,7 +253,7 @@ app.delete('/api/vault/lists/:id', withAccount(async (req, res, acct) => {
 app.get('/api/ltv', async (_, res) => {
   try {
     const result = await query('SELECT * FROM ltv_view');
-    res.json(result.rows);
+    res.json({ rows: result.rows });
   } catch {
     res.status(500).json({ error: 'ltv fetch failed' });
   }
@@ -456,4 +456,4 @@ app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
 
-/*  End of File – Last modified 2025-07-19 */
+/*  End of File – Last modified 2025-07-20 */


### PR DESCRIPTION
## Summary
- return `{ rows: ... }` from the LTV endpoint so the front-end reads data.rows
- show `LtvCard` on the analytics dashboard
- record update in project plan revision log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68787c9f6c90832189d8d0169eb5c99c