### PR TITLE
Add automated setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ See [docs/PROJECT_PLAN.md](docs/PROJECT_PLAN.md) for the complete project plan.
 For step-by-step setup instructions, open [docs/instructions.html](docs/instructions.html) in your browser.
 
 ## Setup
-1. Copy `.env.example` to `.env` and edit `DATABASE_URL`.
-2. Review required environment variables in docs/PROD_ENV.md
-3. Run `npm run init-db` to create the database schema if needed.
-4. Start the server with `npm start`.
+1. Place this project on your Desktop inside a folder named `obo2`.
+2. For automated setup, run `npm run setup` from that folder and follow the prompts.
+3. Or perform the manual steps:
+   - Copy `.env.example` to `.env` and edit `DATABASE_URL`.
+   - Review required environment variables in docs/PROD_ENV.md
+   - Run `npm run init-db` to create the database schema if needed.
+   - Start the server with `npm start`.
 
 ## Development
 

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -630,3 +630,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-19: Fixed profile visitors analytics endpoint to return proper count.
 - 2025-07-20: Updated LTV endpoint response and integrated LtvCard into analytics dashboard.
 - 2025-07-22: Surfaced Top Fans card beside ProfileVisitors on Analytics page.
+- 2025-07-18: Added automated setup script and interactive instructions.

--- a/docs/instructions.html
+++ b/docs/instructions.html
@@ -16,7 +16,7 @@
 </head>
 <body>
   <h1>Project Setup & Usage</h1>
-  <section>
+  <section class="setup-step">
     <h2>Prerequisites (macOS)</h2>
     <p>Begin with Homebrew and a few basic tools.</p>
     <ol>
@@ -31,10 +31,19 @@ createdb ofdb</code></pre></li>
       <li>Clone this repository and enter the folder:<pre><code>git clone &lt;repo-url&gt;
 cd obo18</code></pre></li>
     </ol>
+    <button class="next-btn">Next</button>
   </section>
 
+  <section class="setup-step">
+    <h2>Automated Setup</h2>
+    <p>Place this entire project folder on your Desktop and name the folder <code>obo2</code>. Open a terminal in that directory.</p>
+    <p>Click "Run Setup" below (requires Node integration) or run <code>npm run setup</code> manually.</p>
+    <button onclick="runSetup()">Run Setup</button>
+    <pre id="setup-log"></pre>
+    <button class="next-btn">Next</button>
+  </section>
 
-  <section>
+  <section class="setup-step">
     <h2>Install Dependencies</h2>
     <ul>
       <li>Run <code>npm test</code> once to install dependencies and execute the test suite.</li>
@@ -43,9 +52,10 @@ cd obo18</code></pre></li>
       <li>Initialize the database with <code>npm run init-db</code>.</li>
       <li>Review required environment variables in <code>docs/PROD_ENV.md</code> before deploying.</li>
     </ul>
+    <button class="next-btn">Next</button>
   </section>
 
-  <section>
+  <section class="setup-step">
     <h2>Initialize & Start the App</h2>
     <p>Before launching the main server, start the admin dashboard to configure API keys:</p>
     <ul>
@@ -55,9 +65,10 @@ cd obo18</code></pre></li>
       <li>For future runs, you can start the app directly with <code>npm start</code>.</li>
     </ul>
     <p>Once the server is running, open <code>http://localhost:3000</code> in your browser to access the application.</p>
+    <button class="next-btn">Next</button>
   </section>
 
-  <section>
+  <section class="setup-step">
     <h2>Features Overview</h2>
     <ul>
       <li><b>Full Sync</b> (A-1) – Fetches all fans, messages, and purchases into the database.</li>
@@ -75,6 +86,27 @@ cd obo18</code></pre></li>
       <li><b>LTV Scoreboard</b> (F-1) – Leaderboard of top fans by lifetime value (requires nightly sync).</li>
     </ul>
   </section>
+
+  <script>
+    const steps = document.querySelectorAll('.setup-step');
+    const buttons = document.querySelectorAll('.next-btn');
+    buttons.forEach((btn, idx) => btn.addEventListener('click', () => {
+      steps[idx].style.display = 'none';
+      if (idx + 1 < steps.length) steps[idx + 1].style.display = 'block';
+    }));
+    steps.forEach((step, i) => { if (i > 0) step.style.display = 'none'; });
+    function runSetup() {
+      if (typeof require === 'undefined') {
+        alert('Run `npm run setup` in a terminal if this button does nothing.');
+        return;
+      }
+      const { exec } = require('child_process');
+      const log = document.getElementById('setup-log');
+      const child = exec('npm run setup');
+      child.stdout.on('data', d => log.textContent += d);
+      child.stderr.on('data', d => log.textContent += d);
+    }
+  </script>
 </body>
 </html>
-<!-- End of File – Last modified 2025-07-17 -->
+<!-- End of File – Last modified 2025-07-18 -->

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "SKIP_DB=1 node test/run.js",
     "admin": "node src/server/admin.js",
     "db:init": "node scripts/initDb.js",
-    "init-db": "node scripts/initDb.js"
+    "init-db": "node scripts/initDb.js",
+    "setup": "node scripts/autoSetup.js"
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",

--- a/scripts/autoSetup.js
+++ b/scripts/autoSetup.js
@@ -1,0 +1,55 @@
+/*  OnlyFans Automation Manager
+    File: autoSetup.js
+    Purpose: automated CLI setup helper
+    Created: 2025-07-18 – v1.0 */
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+function wait(message) {
+  return new Promise(resolve => rl.question(message, () => resolve()));
+}
+
+async function run() {
+  const desktop = path.join(process.env.HOME || process.env.USERPROFILE || '.', 'Desktop');
+  const targetDir = path.join(desktop, 'obo2');
+  if (!fs.existsSync(targetDir)) {
+    fs.mkdirSync(targetDir, { recursive: true });
+  }
+
+  const cwdName = path.basename(process.cwd());
+  if (cwdName !== 'obo2') {
+    console.log('Please run this script from the "obo2" folder located on your Desktop.');
+    rl.close();
+    return;
+  }
+
+  await wait('Step 1: Install dependencies and run tests. Press Enter to continue...');
+  execSync('npm test', { stdio: 'inherit' });
+
+  await wait('Step 2: Initialize the database. Press Enter to continue...');
+  execSync('npm run init-db', { stdio: 'inherit' });
+
+  await wait('Step 3: Start the server. Press Enter to continue...');
+  execSync('npm start', { stdio: 'inherit' });
+
+  const openCmd = process.platform === 'win32'
+    ? 'start "" http://localhost:3000'
+    : process.platform === 'darwin'
+      ? 'open http://localhost:3000'
+      : 'xdg-open http://localhost:3000';
+  execSync(openCmd);
+  rl.close();
+}
+
+run().catch(err => {
+  console.error(err);
+  rl.close();
+});
+
+/*  End of File – Last modified 2025-07-18 */
+


### PR DESCRIPTION
## Summary
- add CLI helper for auto setup and `npm run setup`
- document automated setup in README
- document revision in PROJECT_PLAN
- add interactive setup section in instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879dc6d8c0c8321b38f61a2ca7486ff