### PR TITLE
Add start-here script for initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ See [docs/PROJECT_PLAN.md](docs/PROJECT_PLAN.md) for the complete project plan.
 For step-by-step setup instructions, open [docs/instructions.html](docs/instructions.html) in your browser.
 
 ## Setup
-1. Place this project on your Desktop inside a folder named `obo2`.
-2. For automated setup, run `npm run setup` from that folder and follow the prompts.
-3. Or perform the manual steps:
+1. Run `node start-here.js` from the repo root to create your Desktop folder, `.env` and encrypt API keys.
+2. Place this project on your Desktop inside the folder you specified (e.g. `obo2`).
+3. For automated setup, run `npm run setup` from that folder and follow the prompts.
+4. Or perform the manual steps:
    - Copy `.env.example` to `.env` and edit `DATABASE_URL`.
    - Review required environment variables in docs/PROD_ENV.md
    - Run `npm run init-db` to create the database schema if needed.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -631,3 +631,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-20: Updated LTV endpoint response and integrated LtvCard into analytics dashboard.
 - 2025-07-22: Surfaced Top Fans card beside ProfileVisitors on Analytics page.
 - 2025-07-18: Added automated setup script and interactive instructions.
+- 2025-07-18: Added start-here.js quick-start script for folder and key setup.

--- a/docs/instructions.html
+++ b/docs/instructions.html
@@ -30,6 +30,7 @@
 createdb ofdb</code></pre></li>
       <li>Clone this repository and enter the folder:<pre><code>git clone &lt;repo-url&gt;
 cd obo18</code></pre></li>
+      <li>Run <code>node start-here.js</code> to create your Desktop folder and initial <code>.env</code>.</li>
     </ol>
     <button class="next-btn">Next</button>
   </section>

--- a/start-here.js
+++ b/start-here.js
@@ -1,0 +1,50 @@
+/*  OnlyFans Automation Manager
+    File: start-here.js
+    Purpose: quick start script to create project folder and encrypted .env
+    Created: 2025-07-18 – v1.0 */
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import readline from 'readline';
+import sodium from 'libsodium-wrappers';
+import { sealString } from './src/server/security/secureKeys.js';
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+function ask(q) {
+  return new Promise(resolve => rl.question(q, a => resolve(a.trim())));
+}
+
+async function run() {
+  const folder = await ask('Desktop folder name: ');
+  const dbName = await ask('Database name: ');
+  const ofKey = await ask('OnlyFans API key: ');
+  const oaKey = await ask('OpenAI API key: ');
+
+  const desktop = path.join(os.homedir(), 'Desktop');
+  const targetDir = path.join(desktop, folder);
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  await sodium.ready;
+  const { publicKey, privateKey } = sodium.crypto_box_keypair();
+  const pubHex = Buffer.from(publicKey).toString('hex');
+  const privHex = Buffer.from(privateKey).toString('hex');
+
+  const sealedOf = await sealString(ofKey, pubHex);
+  const sealedOa = await sealString(oaKey, pubHex);
+  const dbUrl = `postgres://localhost:5432/${dbName}`;
+
+  const env = `DATABASE_URL=${dbUrl}\nKEY_PUBLIC=${pubHex}\nKEY_PRIVATE=${privHex}\nONLYFANS_API_KEY=${sealedOf}\nOPENAI_API_KEY=${sealedOa}\n`;
+  fs.writeFileSync(path.join(targetDir, '.env'), env);
+
+  console.log('Setup complete.');
+  console.log(`Database URL: ${dbUrl}`);
+  rl.close();
+}
+
+run().catch(err => {
+  console.error(err);
+  rl.close();
+});
+
+/*  End of File – Last modified 2025-07-18 */


### PR DESCRIPTION
## Summary
- add `start-here.js` to initialise a Desktop folder, create `.env` and encrypt API keys
- document new script in README setup steps
- mention running `node start-here.js` in instructions
- log addition in project plan revision log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879e87fc5fc832187018a90e89577b8