### PR TITLE
Add startHere automation script

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -632,3 +632,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-22: Surfaced Top Fans card beside ProfileVisitors on Analytics page.
 - 2025-07-18: Added automated setup script and interactive instructions.
 - 2025-07-18: Added start-here.js quick-start script for folder and key setup.
+- 2025-07-25: Added startHere.js script for automated setup with database creation and server start.

--- a/scripts/startHere.js
+++ b/scripts/startHere.js
@@ -1,0 +1,69 @@
+/*  OnlyFans Automation Manager
+    File: startHere.js
+    Purpose: interactive setup for local development
+    Created: 2025-07-25 – v1.0 */
+
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import readline from 'readline';
+import { execSync } from 'child_process';
+import sodium from 'libsodium-wrappers';
+import { sealString } from '../src/server/security/secureKeys.js';
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+function ask(question) {
+  return new Promise(resolve => rl.question(question, a => resolve(a.trim())));
+}
+
+async function run() {
+  const folder = await ask('Project folder name on Desktop: ');
+  const dbName = await ask('Database name: ');
+  const ofKey = await ask('OnlyFans API key: ');
+  const oaKey = await ask('OpenAI API key: ');
+
+  const desktop = path.join(os.homedir(), 'Desktop');
+  const targetDir = path.join(desktop, folder);
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  await sodium.ready;
+  const { publicKey, privateKey } = sodium.crypto_box_keypair();
+  const pubHex = Buffer.from(publicKey).toString('hex');
+  const privHex = Buffer.from(privateKey).toString('hex');
+
+  const sealedOf = await sealString(ofKey, pubHex);
+  const sealedOa = await sealString(oaKey, pubHex);
+  const dbUrl = `postgres://localhost:5432/${dbName}`;
+
+  const env = [
+    `DATABASE_URL=${dbUrl}`,
+    `KEY_PUBLIC=${pubHex}`,
+    `KEY_PRIVATE=${privHex}`,
+    `ONLYFANS_API_KEY=${sealedOf}`,
+    `OPENAI_API_KEY=${sealedOa}`,
+    ''
+  ].join('\n');
+  fs.writeFileSync(path.join(targetDir, '.env'), env);
+
+  fs.writeFileSync('.starthere.json', JSON.stringify({ folder: targetDir }, null, 2));
+
+  try {
+    execSync(`createdb ${dbName}`, { stdio: 'inherit' });
+  } catch (err) {
+    console.warn('createdb failed, continuing with init-db');
+  }
+
+  execSync('npm test', { cwd: targetDir, stdio: 'inherit' });
+  execSync('npm run init-db', { cwd: targetDir, stdio: 'inherit' });
+  execSync('npm start', { cwd: targetDir, stdio: 'inherit' });
+
+  rl.close();
+}
+
+run().catch(err => {
+  console.error(err);
+  rl.close();
+});
+
+/*  End of File – Last modified 2025-07-25 */


### PR DESCRIPTION
## Summary
- add new interactive `scripts/startHere.js` to configure local project
- document the new setup script in the project plan revision log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879f95a0c908321a61b82b80ed7f4d0