### PR TITLE
Improve start-here.js dependency handling

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -634,3 +634,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-07-18: Added start-here.js quick-start script for folder and key setup.
 - 2025-07-25: Added startHere.js script for automated setup with database creation and server start.
 - 2025-08-05: Updated start-here.js to copy the project, create the database, run tests and launch the app in one step.
+- 2025-08-06: start-here.js now checks for libsodium-wrappers and prompts to run `npm install` or `npm test` if missing.

--- a/start-here.js
+++ b/start-here.js
@@ -7,8 +7,19 @@ import path from 'path';
 import os from 'os';
 import readline from 'readline';
 import { execSync } from 'child_process';
-import sodium from 'libsodium-wrappers';
+import { createRequire } from 'module';
 import { sealString } from './src/server/security/secureKeys.js';
+
+const require = createRequire(import.meta.url);
+let sodium;
+try {
+  sodium = require('libsodium-wrappers');
+} catch (err) {
+  console.error(
+    'libsodium-wrappers is missing. Please run `npm install` or `npm test` first.'
+  );
+  process.exit(1);
+}
 
 const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
@@ -74,4 +85,4 @@ run().catch(err => {
   rl.close();
 });
 
-/*  End of File – Last modified 2025-08-05 */
+/*  End of File – Last modified 2025-08-06 */


### PR DESCRIPTION
## Summary
- add runtime check for `libsodium-wrappers` in `start-here.js`
- log a helpful message if the dependency is missing
- record this improvement in `PROJECT_PLAN.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687abc36346083218a576e3f897f1e63