### PR TITLE
Allow Unicode Parker names

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -636,3 +636,4 @@ Lifetime Value – total net spend by a fan.
 - 2025-08-05: Updated start-here.js to copy the project, create the database, run tests and launch the app in one step.
 - 2025-08-06: start-here.js now checks for libsodium-wrappers and prompts to run `npm install` or `npm test` if missing.
 - 2025-08-10: PUT /api/ppv/:id now accepts null scheduleDay and scheduleTime to remove scheduled sends.
+- 2025-08-07: Parker name validation now accepts Unicode letters and curly apostrophes.

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -21,6 +21,19 @@ import { query } from './db/db.js';
 import { schema } from './graphql/schema.js';
 import { logActivity, getActivityLog } from './activityLog.js';
 
+// Helpers for Parker name validation
+const PARKER_NAME_PATTERN = /^[\p{L}\p{M}][\p{L}\p{M}\s\-'’]*$/u;
+
+function isValidParkerName(name) {
+  return typeof name === 'string' && PARKER_NAME_PATTERN.test(name.trim());
+}
+
+function ensureValidParkerName(name, fallback = 'Fan') {
+  if (!name) return fallback;
+  const normalized = name.trim().normalize('NFC');
+  return isValidParkerName(normalized) ? normalized : fallback;
+}
+
 //
 // 1. Ensure .env exists or exit
 //
@@ -300,7 +313,11 @@ app.get('/api/fans', async (req, res) => {
        LIMIT $1`,
       [limit]
     );
-    res.json({ rows: result.rows });
+    const rows = result.rows.map(r => ({
+      ...r,
+      display_name: ensureValidParkerName(r.display_name)
+    }));
+    res.json({ rows });
   } catch {
     res.status(500).json({ error: 'fans fetch failed' });
   }
@@ -485,4 +502,4 @@ app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });
 
-/*  End of File – Last modified 2025-07-24 */
+/*  End of File – Last modified 2025-08-07 */


### PR DESCRIPTION
## Summary
- Add Unicode-aware Parker name validation allowing accented letters and curly apostrophes
- Sanitize fan display names via ensureValidParkerName
- Document Parker name validation update in project plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689529d22a008321966e3244a4c9f236